### PR TITLE
fix: check null pointer before from_raw_parts()

### DIFF
--- a/examples/ascii.rs
+++ b/examples/ascii.rs
@@ -13,7 +13,7 @@ lazy_static::lazy_static! {
 }
 
 fn main() -> anyhow::Result<()> {
-    let mut kbd = KBD_CONTEXT.lock().unwrap();
+    // let mut kbd = KBD_CONTEXT.lock().unwrap();
 
     // let mut ctx: Mutex<Context> = Mutex::new(Context::new().unwrap());
 
@@ -27,10 +27,10 @@ fn main() -> anyhow::Result<()> {
     //     ctx.ascii_char(b'\n')?;
     // }
 
-    KBD_CONTEXT.lock().unwrap().key_down(Key::Shift);
-    KBD_CONTEXT.lock().unwrap().unicode_char_down('1');
-    KBD_CONTEXT.lock().unwrap().unicode_char_up('1');
-    KBD_CONTEXT.lock().unwrap().key_up(Key::Shift);
+    KBD_CONTEXT.lock().unwrap().key_down(Key::Shift).unwrap();
+    KBD_CONTEXT.lock().unwrap().unicode_char_down('1').unwrap();
+    KBD_CONTEXT.lock().unwrap().unicode_char_up('1').unwrap();
+    KBD_CONTEXT.lock().unwrap().key_up(Key::Shift).unwrap();
     
 
     // let c = 'b'; // â Q q ¡(shift+altgr) ^ \\

--- a/src/linux_x11/mod.rs
+++ b/src/linux_x11/mod.rs
@@ -159,12 +159,17 @@ unsafe fn create_key_map(
                     ffi::XkbKeycodeToKeysym(display, keycode, group as c_uint, level as c_uint);
                 let mut modifiers = 0;
 
-                let maps =
-                    std::slice::from_raw_parts((*key_type).map, (*key_type).map_count as usize);
-                for map in maps {
-                    if map.active == ffi::True && map.level == level {
-                        modifiers = map.mods.mask;
-                        break;
+                if !(*key_type).map.is_null()
+                    && (*key_type).map.is_aligned()
+                    && (*key_type).map_count as usize <= isize::MAX as usize
+                {
+                    let maps =
+                        std::slice::from_raw_parts((*key_type).map, (*key_type).map_count as usize);
+                    for map in maps {
+                        if map.active == ffi::True && map.level == level {
+                            modifiers = map.mods.mask;
+                            break;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Add checks before `from_raw_parts()`, or this function may cause crash with rust `1.79`.

rust `1.75` works fine.

I've printed `(*key_type).map` and `(*key_type).map_count`, they are sometimes `0`.


