### PR TITLE
slice_from_raw_parts(), pre check to avoid crash

### DIFF
--- a/examples/ascii.rs
+++ b/examples/ascii.rs
@@ -13,7 +13,7 @@ lazy_static::lazy_static! {
 }
 
 fn main() -> anyhow::Result<()> {
-    let mut kbd = KBD_CONTEXT.lock().unwrap();
+    // let mut kbd = KBD_CONTEXT.lock().unwrap();
 
     // let mut ctx: Mutex<Context> = Mutex::new(Context::new().unwrap());
 
@@ -27,10 +27,10 @@ fn main() -> anyhow::Result<()> {
     //     ctx.ascii_char(b'\n')?;
     // }
 
-    KBD_CONTEXT.lock().unwrap().key_down(Key::Shift);
-    KBD_CONTEXT.lock().unwrap().unicode_char_down('1');
-    KBD_CONTEXT.lock().unwrap().unicode_char_up('1');
-    KBD_CONTEXT.lock().unwrap().key_up(Key::Shift);
+    KBD_CONTEXT.lock().unwrap().key_down(Key::Shift).unwrap();
+    KBD_CONTEXT.lock().unwrap().unicode_char_down('1').unwrap();
+    KBD_CONTEXT.lock().unwrap().unicode_char_up('1').unwrap();
+    KBD_CONTEXT.lock().unwrap().key_up(Key::Shift).unwrap();
     
 
     // let c = 'b'; // â Q q ¡(shift+altgr) ^ \\

--- a/src/linux_x11/mod.rs
+++ b/src/linux_x11/mod.rs
@@ -159,12 +159,18 @@ unsafe fn create_key_map(
                     ffi::XkbKeycodeToKeysym(display, keycode, group as c_uint, level as c_uint);
                 let mut modifiers = 0;
 
-                let maps =
-                    std::slice::from_raw_parts((*key_type).map, (*key_type).map_count as usize);
-                for map in maps {
-                    if map.active == ffi::True && map.level == level {
-                        modifiers = map.mods.mask;
-                        break;
+                if !(*key_type).map.is_null()
+                    // to-do: Replace to `ptr.is_aligned()`` when upgrading to Rust 1.79
+                    && crate::utils::is_aligned((*key_type).map)
+                    && (*key_type).map_count as usize <= isize::MAX as usize
+                {
+                    let maps =
+                        std::slice::from_raw_parts((*key_type).map, (*key_type).map_count as usize);
+                    for map in maps {
+                        if map.active == ffi::True && map.level == level {
+                            modifiers = map.mods.mask;
+                            break;
+                        }
                     }
                 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,3 +2,9 @@ mod non_zero;
 
 #[allow(unused)]
 pub use non_zero::*;
+
+#[inline]
+pub fn is_aligned<T>(ptr: *const T) -> bool {
+    let align = std::mem::align_of::<T>();
+    (ptr as usize) & (align - 1) == 0
+}


### PR DESCRIPTION
Use inner pre check code in `from_raw_parts()`.

Simple `is_aligned()` implement for `1.75`, because `ptr.is_aligned()` is marked stable in `1.79`.
