### PR TITLE
tmp `is_aligned()` for rust 1.75

### DIFF
--- a/src/linux_x11/mod.rs
+++ b/src/linux_x11/mod.rs
@@ -160,7 +160,8 @@ unsafe fn create_key_map(
                 let mut modifiers = 0;
 
                 if !(*key_type).map.is_null()
-                    && (*key_type).map.is_aligned()
+                    // to-do: Replace to `ptr.is_aligned()`` when upgrading to Rust 1.79
+                    && crate::utils::is_aligned((*key_type).map)
                     && (*key_type).map_count as usize <= isize::MAX as usize
                 {
                     let maps =

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,3 +2,9 @@ mod non_zero;
 
 #[allow(unused)]
 pub use non_zero::*;
+
+#[inline]
+pub fn is_aligned<T>(ptr: *const T) -> bool {
+    let align = std::mem::align_of::<T>();
+    (ptr as usize) & (align - 1) == 0
+}


### PR DESCRIPTION
Simple implementation of `is_aligned()` for rust `1.75`, because `ptr.is_aligned()` is marked stable untile `1.79`.